### PR TITLE
fix: remove inversions

### DIFF
--- a/convert_to_mappings.ipynb
+++ b/convert_to_mappings.ipynb
@@ -38,7 +38,7 @@
    "outputs": [],
    "source": [
     "# remove inversions\n",
-    "df['chords'] = df['chords'].apply(lambda s: re.sub(r\"/[^/]*$\", \"\", s))\n"
+    "df['chords'] = df['chords'].apply(lambda s: \" \".join(re.sub(r\"/[^/]*$\", \"\", chord) for chord in s.split()))"
    ]
   },
   {
@@ -197,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed an issue in pitch shift pre-processing where the regex was only removing the final instance of a chord inversion in a progression. Now, it removes them all.